### PR TITLE
Adding Travis CI for syntax checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: php
+php:
+  - '7.3'
+script:
+  - './syntaxcheck.sh'

--- a/syntaxcheck.sh
+++ b/syntaxcheck.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+find -name "*.php" | while read f
+do
+	php -d error_reporting=32767 -l $f
+done


### PR DESCRIPTION
Travis CI will check that all `.php` files are syntactically correct.

Travis failed here and will continue to fail until the error on the `master` branch is fixed.  
So I suggest we hold of this PR until that is fixed.