### PR TITLE
Inserts and handle_post function done

### DIFF
--- a/pizzakit-plugin/includes/pizzakit-activator.php
+++ b/pizzakit-plugin/includes/pizzakit-activator.php
@@ -27,6 +27,7 @@ class Pizzakit_Activator {
   			address TEXT,
   			doorCode VARCHAR(10),
         postalCode VARCHAR(6),
+				comments TEXT,
         date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   			PRIMARY KEY (id)
       )';
@@ -38,7 +39,7 @@ class Pizzakit_Activator {
     // WP_ITEMS
     if ($wpdb->get_var('SHOW TABLES LIKE wp_items') != 'wp_items') {
       $sql = 'CREATE TABLE wp_items(
-        name VARCHAR(15) NOT NULL,
+        name VARCHAR(25) NOT NULL,
         price INT NOT NULL,
   			PRIMARY KEY (name)
       )';

--- a/pizzakit-plugin/includes/pizzakit-activator.php
+++ b/pizzakit-plugin/includes/pizzakit-activator.php
@@ -20,16 +20,16 @@ class Pizzakit_Activator {
     // WP_ORDERS
     if ($wpdb->get_var('SHOW TABLES LIKE wp_orders') != 'wp_orders') {
       $sql = 'CREATE TABLE wp_orders(
-        id INTEGER(10) UNSIGNED,
+        id INTEGER(10) UNSIGNED AUTO_INCREMENT,
         email VARCHAR(100),
         name TEXT,
-  			telNr VARCHAR(15),
-  			address TEXT,
-  			doorCode VARCHAR(10),
+  		telNr VARCHAR(15),
+  		address TEXT,
+  		doorCode VARCHAR(10),
         postalCode VARCHAR(6),
-				comments TEXT,
+		comments TEXT,
         date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  			PRIMARY KEY (id)
+  		PRIMARY KEY (id)
       )';
 
       dbDelta($sql);

--- a/pizzakit-plugin/includes/pizzakit.php
+++ b/pizzakit-plugin/includes/pizzakit.php
@@ -41,31 +41,20 @@ class Pizzakit {
 
 		global $wpdb;
 
-		// Get the ID to use for this order
-		$_result = $wpdb->get_results("SELECT MAX(id)+1 AS maxID FROM wp_orders", OBJECT);
-		$_orderID	= $_result[0]->maxID;
-
-		//insert into orders
-		$sql = "INSERT INTO wp_orders(id, email, name, telNr, address, doorCode, postalCode, comments) VALUES ("
-				. $_orderID . ", '"
-				. $_data["email"] . "', '"
-				. $_data["name"] . "', '"
-				. $_data["telNr"] . "', '"
-				. $_data["address"] . "', '"
-				. $_data["doorCode"] . "', '"
-				. $_data["postalCode"] . "', '"
-				. $_data["comments"] . "')";
-		$wpdb->query($sql);
+		//insert into orders, using insert() function to get it prepared
+		$table = $wpdb->prefix. 'orders';
+		$data = array('id' => null,'email' => $_data["email"],'name' => $_data["name"],'telNr' => $_data["telNr"],
+			'address' => $_data["address"], 'doorCode' => $_data["doorCode"], 'postalCode' => $_data["postalCode"], 'comments' => $_data["comments"]);
+		$format = array('%d','%s','%s','%s','%s','%s','%s','%s');
+		$wpdb->insert($table,$data,$format);
+		$lastid = $wpdb->insert_id;
 
 		//insert into entries
 		foreach ($_data["cart"] as $_item){
-			$sql = "INSERT INTO wp_entries(orderID, item, quantity)
-				VALUES ("
-					. $_orderID . ", '"
-					. $_item[0] . "', '"
-					. $_item[1] . "')";
-
-					$wpdb->query($sql);
+			$table2 = $wpdb->prefix. 'entries';
+			$data = array('orderID' => $lastid,'item'=>$_item[0],'quantity'=>$_item[1]);
+			$format = array('%d','%s','%d');
+			$wpdb->insert($table2,$data,$format);
 		}
 	}
 }

--- a/pizzakit-plugin/includes/pizzakit.php
+++ b/pizzakit-plugin/includes/pizzakit.php
@@ -33,7 +33,7 @@ class Pizzakit {
 		// In this the example it's "pizzakitFormSubmission".
 		if (isset($data["pizzakitFormSubmission"])) {
 
-			// "Critical error" is caused at this line.
+			// ------ "Critical error" is caused at this line.
 			Pizzakit::insert_into_tables($data);
 
 			// Respond with a JSON object by calling
@@ -55,7 +55,7 @@ class Pizzakit {
 				. $_data["comments"] . ')';
 		$wpdb->query($sql);
 
-		// Get the ID to use for this order
+		// ------ Get the ID to use for this order - might be broken
 		$_orderID = $wpdb->get_results("SELECT MAX(id)+1 FROM wp_orders", OBJECT);
 
 		//insert into entries

--- a/pizzakit-plugin/includes/pizzakit.php
+++ b/pizzakit-plugin/includes/pizzakit.php
@@ -20,46 +20,54 @@ class Pizzakit {
 	}
 
 	private static function handle_post() {
+
 		$json = file_get_contents("php://input");
+		//$json = file_get_contents("../wp-content/plugins/pizza-plugin/testjson.txt");
+		//file_put_contents("../wp-content/plugins/pizza-plugin/contents.txt", $json);
 		$data = json_decode($json, true);
+		//file_put_contents("../wp-content/plugins/pizza-plugin/contents2.txt", $data);
+
 
 		// Create a "secret" JSON field that's only set when posting from our
 		// form so that we don't respond to other post requests.
 		// In this the example it's "pizzakitFormSubmission".
 		if (isset($data["pizzakitFormSubmission"])) {
 
-			// insert the data into the different tables
-			// This assumes that the data is in a map-structure with the column names as keys
-			insert_into_tables($data);
+			// "Critical error" is caused at this line.
+			Pizzakit::insert_into_tables($data);
 
 			// Respond with a JSON object by calling
 			// wp_send_json($response);
 			// where $response is an associative array.
+		}
 	}
-
 
 	private static function insert_into_tables($_data){
 
 		//insert into orders
-		$sql = "INSERT INTO wp_orders(email, name, telNr, address, doorCode, postalCode)
-			VALUES ("
-				. $_data['email'] . ", "
-				. $_data['name'] . ", "
-				. $_data['telNr'] . ", "
-				. $_data['address'] . ", "
-				. $_data['doorCode'] . ", "
-				. $_data['postalCode'] . ",)";
-
+		$sql = 'INSERT INTO wp_orders(email, name, telNr, address, doorCode, postalCode) VALUES ('
+				. $_data["email"] . ', '
+				. $_data["name"] . ', '
+				. $_data["telNr"] . ', '
+				. $_data["address"] . ', '
+				. $_data["doorCode"] . ', '
+				. $_data["postalCode"] . ', '
+				. $_data["comments"] . ')';
 		$wpdb->query($sql);
+
+		// Get the ID to use for this order
+		$_orderID = $wpdb->get_results("SELECT MAX(id)+1 FROM wp_orders", OBJECT);
 
 		//insert into entries
-		$sql = "INSERT INTO wp_entries(orderID, item, quantity)
-			VALUES (
-				(SELECT MAX(id)+1 FROM wp_orders)), "
-				. $_data['item'] . ", "
-				. $_data['quantity'] . ")";
+		foreach ($_data['cart'] as $_item){
+			$sql = "INSERT INTO wp_entries(orderID, item, quantity)
+				VALUES ("
+					. $_orderID . ", "
+					. $_item[0] . ", "
+					. $_item[1] . ")";
 
-		$wpdb->query($sql);
+					$wpdb->query($sql);
+		}
 
 	}
 }

--- a/pizzakit-plugin/includes/pizzakit.php
+++ b/pizzakit-plugin/includes/pizzakit.php
@@ -22,18 +22,13 @@ class Pizzakit {
 	private static function handle_post() {
 
 		$json = file_get_contents("php://input");
-		//$json = file_get_contents("../wp-content/plugins/pizza-plugin/testjson.txt");
-		//file_put_contents("../wp-content/plugins/pizza-plugin/contents.txt", $json);
 		$data = json_decode($json, true);
-		//file_put_contents("../wp-content/plugins/pizza-plugin/contents2.txt", $data);
-
 
 		// Create a "secret" JSON field that's only set when posting from our
 		// form so that we don't respond to other post requests.
 		// In this the example it's "pizzakitFormSubmission".
 		if (isset($data["pizzakitFormSubmission"])) {
 
-			// ------ "Critical error" is caused at this line.
 			Pizzakit::insert_into_tables($data);
 
 			// Respond with a JSON object by calling
@@ -44,31 +39,34 @@ class Pizzakit {
 
 	private static function insert_into_tables($_data){
 
+		global $wpdb;
+
+		// Get the ID to use for this order
+		$_result = $wpdb->get_results("SELECT MAX(id)+1 AS maxID FROM wp_orders", OBJECT);
+		$_orderID	= $_result[0]->maxID;
+
 		//insert into orders
-		$sql = 'INSERT INTO wp_orders(email, name, telNr, address, doorCode, postalCode) VALUES ('
-				. $_data["email"] . ', '
-				. $_data["name"] . ', '
-				. $_data["telNr"] . ', '
-				. $_data["address"] . ', '
-				. $_data["doorCode"] . ', '
-				. $_data["postalCode"] . ', '
-				. $_data["comments"] . ')';
+		$sql = "INSERT INTO wp_orders(id, email, name, telNr, address, doorCode, postalCode, comments) VALUES ("
+				. $_orderID . ", '"
+				. $_data["email"] . "', '"
+				. $_data["name"] . "', '"
+				. $_data["telNr"] . "', '"
+				. $_data["address"] . "', '"
+				. $_data["doorCode"] . "', '"
+				. $_data["postalCode"] . "', '"
+				. $_data["comments"] . "')";
 		$wpdb->query($sql);
 
-		// ------ Get the ID to use for this order - might be broken
-		$_orderID = $wpdb->get_results("SELECT MAX(id)+1 FROM wp_orders", OBJECT);
-
 		//insert into entries
-		foreach ($_data['cart'] as $_item){
+		foreach ($_data["cart"] as $_item){
 			$sql = "INSERT INTO wp_entries(orderID, item, quantity)
 				VALUES ("
-					. $_orderID . ", "
-					. $_item[0] . ", "
-					. $_item[1] . ")";
+					. $_orderID . ", '"
+					. $_item[0] . "', '"
+					. $_item[1] . "')";
 
 					$wpdb->query($sql);
 		}
-
 	}
 }
 

--- a/pizzakit-plugin/includes/pizzakit.php
+++ b/pizzakit-plugin/includes/pizzakit.php
@@ -31,9 +31,8 @@ class Pizzakit {
 
 			Pizzakit::insert_into_tables($data);
 
-			// Respond with a JSON object by calling
-			// wp_send_json($response);
-			// where $response is an associative array.
+			$response = array('orderPlaced' => true);
+			wp_send_json($response);
 		}
 	}
 


### PR DESCRIPTION
Verified that it handles POST-requests correctly too by sending this JSON data as POST using postman:

{
  "cart": [
    ["thing", 1],
    ["other", 1]
  ],
  "email": "person@mail.se",
  "name": "Alfred",
  "telNr": "0722823904",
  "address": "gatuvägen 1",
  "doorCode": "12",
  "postalCode": "12451",
  "comments": "gg bror",
  "pizzakitFormSubmission": true
}

Note that you have to insert "thing" and "other" into the wp_items table before expecting this test data to go through, as we have foreign key constraints that ensures only accepted items get registered.