### PR TITLE
Added functions for adding and removing items from the wp_items table in the database

### DIFF
--- a/pizzakit-plugin/includes/pizzakit-activator.php
+++ b/pizzakit-plugin/includes/pizzakit-activator.php
@@ -20,15 +20,16 @@ class Pizzakit_Activator {
     // WP_ORDERS
     if ($wpdb->get_var('SHOW TABLES LIKE wp_orders') != 'wp_orders') {
       $sql = 'CREATE TABLE wp_orders(
-        id INTEGER(10) UNSIGNED,
+        id INTEGER(10) UNSIGNED AUTO_INCREMENT,
         email VARCHAR(100),
         name TEXT,
-  			telNr VARCHAR(15),
-  			address TEXT,
-  			doorCode VARCHAR(10),
+  		telNr VARCHAR(15),
+  		address TEXT,
+  		doorCode VARCHAR(10),
         postalCode VARCHAR(6),
+		comments TEXT,
         date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  			PRIMARY KEY (id)
+  		PRIMARY KEY (id)
       )';
 
       dbDelta($sql);
@@ -38,7 +39,7 @@ class Pizzakit_Activator {
     // WP_ITEMS
     if ($wpdb->get_var('SHOW TABLES LIKE wp_items') != 'wp_items') {
       $sql = 'CREATE TABLE wp_items(
-        name VARCHAR(15) NOT NULL,
+        name VARCHAR(25) NOT NULL,
         price INT NOT NULL,
   			PRIMARY KEY (name)
       )';

--- a/pizzakit-plugin/includes/pizzakit-activator.php
+++ b/pizzakit-plugin/includes/pizzakit-activator.php
@@ -23,13 +23,13 @@ class Pizzakit_Activator {
         id INTEGER(10) UNSIGNED AUTO_INCREMENT,
         email VARCHAR(100),
         name TEXT,
-  		telNr VARCHAR(15),
-  		address TEXT,
-  		doorCode VARCHAR(10),
+  			telNr VARCHAR(15),
+  			address TEXT,
+  			doorCode VARCHAR(10),
         postalCode VARCHAR(6),
-		comments TEXT,
+				comments TEXT,
         date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  		PRIMARY KEY (id)
+  			PRIMARY KEY (id)
       )';
 
       dbDelta($sql);

--- a/pizzakit-plugin/includes/pizzakit.php
+++ b/pizzakit-plugin/includes/pizzakit.php
@@ -31,25 +31,24 @@ class Pizzakit {
 
 			Pizzakit::insert_into_tables($data);
 
-			// Respond with a JSON object by calling
-			// wp_send_json($response);
-			// where $response is an associative array.
+			$response = array('orderPlaced' => true);
+			wp_send_json($response);
 		}
 
-		// Send a JSON object with the tag "addItemsToMenu"=true
-		// and an array of [itemname, price] to add them to the
-		// wp_items database table
 		if (isset($data["addItemsToMenu"])){
 
 			Pizzakit::add_menu_items($data);
+			
+			$response = array('menuItemAdded' => true);
+			wp_send_json($response);
 		}
 
-		// Send a JSON object with the tag "removeItemsFromMenu"=true
-		// and an array of item names to remove them from the
-		// wp_items database table
 		if (isset($data["removeItemsFromMenu"])){
 
 			Pizzakit::remove_menu_items($data);
+			
+			$response = array('menuItemRemoved' => true);
+			wp_send_json($response);
 		}
 	}
 

--- a/pizzakit-plugin/includes/pizzakit.php
+++ b/pizzakit-plugin/includes/pizzakit.php
@@ -38,7 +38,7 @@ class Pizzakit {
 		if (isset($data["addItemsToMenu"])){
 
 			Pizzakit::add_menu_items($data);
-			
+
 			$response = array('menuItemAdded' => true);
 			wp_send_json($response);
 		}
@@ -46,7 +46,7 @@ class Pizzakit {
 		if (isset($data["removeItemsFromMenu"])){
 
 			Pizzakit::remove_menu_items($data);
-			
+
 			$response = array('menuItemRemoved' => true);
 			wp_send_json($response);
 		}
@@ -57,44 +57,44 @@ class Pizzakit {
 		global $wpdb;
 
 		//insert into orders, using insert() function to get it prepared
-		$table = $wpdb->prefix. 'orders';
-		$data = array('id' => null,'email' => $_data["email"],'name' => $_data["name"],'telNr' => $_data["telNr"],
+		$_table = $wpdb->prefix. 'orders';
+		$_dataArr = array('id' => null,'email' => $_data["email"],'name' => $_data["name"],'telNr' => $_data["telNr"],
 			'address' => $_data["address"], 'doorCode' => $_data["doorCode"], 'postalCode' => $_data["postalCode"], 'comments' => $_data["comments"]);
-		$format = array('%d','%s','%s','%s','%s','%s','%s','%s');
-		$wpdb->insert($table,$data,$format);
-		$lastid = $wpdb->insert_id;
+		$_format = array('%d','%s','%s','%s','%s','%s','%s','%s');
+		$wpdb->insert($_table,$_dataArr,$_format);
+		$_lastid = $wpdb->insert_id;
 
 		//insert into entries
 		foreach ($_data["cart"] as $_item){
-			$table2 = $wpdb->prefix. 'entries';
-			$data = array('orderID' => $lastid,'item'=>$_item[0],'quantity'=>$_item[1]);
-			$format = array('%d','%s','%d');
-			$wpdb->insert($table2,$data,$format);
+			$_table = $wpdb->prefix. 'entries';
+			$_dataArr = array('orderID' => $_lastid,'item'=>$_item[0],'quantity'=>$_item[1]);
+			$_format = array('%d','%s','%d');
+			$wpdb->insert($_table,$_dataArr,$_format);
 		}
 	}
 
 	private static function add_menu_items($_data){
 
 		global $wpdb;
-		$table = $wpdb->prefix . 'items';
+		$_table = $wpdb->prefix . 'items';
 
 		//insert items
 		foreach ($_data["items"] as $_item){
 			$_dataArr = array('name' => $_item[0],'price'=>$_item[1]);
-			$format = array('%s','%d');
-			$wpdb->insert($table,$_dataArr,$format);
+			$_format = array('%s','%d');
+			$wpdb->insert($_table,$_dataArr,$_format);
 		}
 	}
 
 	private static function remove_menu_items($_data){
 
 		global $wpdb;
-		$table = $wpdb->prefix . 'items';
+		$_table = $wpdb->prefix . 'items';
 
 		//remove items
 		foreach ($_data["items"] as $_item){
-			$_where = array('name' => $_item);
-			$wpdb->delete($table,$_where);
+			$_whereArr = array('name' => $_item);
+			$wpdb->delete($_table,$_whereArr);
 		}
 	}
 


### PR DESCRIPTION
The following additions makes it possible to add and remove items from the wp_items table in the database using POST requests. 

These functions will come in handy when we want to make it possible for our client to add and remove toppings from the menu for example.

Tested using the following JSON objects as POST:
```json
{ // Add_menu_items
	"items": [
		["Picollo",175],
		["Grande",265],
		["Salami mild",20],
		["Salami stark",20],
		["ParmaSkinka",20],
		["Prosciutto Cotto",20],
		["Buffelmozzarella",25],
		["Extra deg",35]
	], 
	"addItemsToMenu": true
}
```
```json
{ // Remove_menu_items
    "items": [
        "Picollo",
        "Grande",
        "Salami mild",
        "Salami stark",
        "ParmaSkinka",
        "Prosciutto Cotto",
        "Buffelmozzarella",
        "Extra deg"
    ],
    "removeItemsFromMenu": true
}```