### PR TITLE
A platform for pane navigation in the Order Form UI

### DIFF
--- a/order-form-ui/index.js
+++ b/order-form-ui/index.js
@@ -1,6 +1,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import App from './src/App';
 import OrderForm from './src/OrderForm';
 
 registerBlockType(
@@ -16,5 +17,6 @@ registerBlockType(
 
 const root = document.getElementById('pizzakit-order-form');
 if (root != null) {
-	ReactDOM.render(<OrderForm post_address="/"/>, root);
+	const app = ReactDOM.render(<App />, root);
+	app.navigateTo(OrderForm, { post_address: '/' });
 }

--- a/order-form-ui/index.js
+++ b/order-form-ui/index.js
@@ -1,7 +1,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './src/App';
+import OrderForm from './src/OrderForm';
 
 registerBlockType(
 	'pizzakit/order-form',
@@ -16,5 +16,5 @@ registerBlockType(
 
 const root = document.getElementById('pizzakit-order-form');
 if (root != null) {
-	ReactDOM.render(<App post_address="/"/>, root);
+	ReactDOM.render(<OrderForm post_address="/"/>, root);
 }

--- a/order-form-ui/src/App.js
+++ b/order-form-ui/src/App.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import './style.scss';
+
+class App extends React.Component {
+	constructor(props) {
+		super(props);
+
+		this.state = { ...App.defaultState };
+	}
+
+	/**
+	 * Changes what this "App" displays as it's child.
+	 * Children displayed from this "App" will get a `navigateTo` function in
+	 * addition to the provided `props` that they can use to navigate
+	 * elsewhere.
+	 * @param {*} reactComponent A string (for a built in type) or a
+	 *                           function/class for a React element.
+	 * @param {*} [props]        Some properties for a React element.
+	 */
+	navigateTo(reactComponent, props) {
+		this.setState({
+			childComponent: reactComponent,
+			childProps: props
+		});
+	}
+
+	render() {
+		return React.createElement(this.state.childComponent, { ...this.state.childProps, navigateTo: this.navigateTo.bind(this) });
+	}
+}
+
+App.defaultState = {
+	childComponent: () => <p>Pizzakit: Order form (something went wrong 😢)</p>,
+	childProps: { }
+}
+
+export default App;

--- a/order-form-ui/src/OrderForm.js
+++ b/order-form-ui/src/OrderForm.js
@@ -5,7 +5,7 @@ import './style.scss';
 
 // Main Application
 // Renders a form and keeps track of items the client has selected
-class App extends React.Component {
+class OrderForm extends React.Component {
 	constructor(props){
 		super(props);
 
@@ -246,4 +246,4 @@ class App extends React.Component {
 	}
 }
 
-export default App;
+export default OrderForm;

--- a/order-form-ui/src/OrderForm.js
+++ b/order-form-ui/src/OrderForm.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Small_item from './Items';
-import './style.scss';
 
 
 // Main Application


### PR DESCRIPTION
This is the minimum overlap between my and @Peptski current tasks. It will make it easy for us both to work on or own stuff without doing the same work twice.

It works by using `App` as a common parent for all panes, and giving them a function (`navigateTo`) in `props` that they can use for navigating to other panes.

**Example:**

index.js
```JSX
import Pane1 from 'Pane1';
// ...
const app = ReactDOM.render(<App />, root);
app.navigateTo(Pane1);
```

Pane1.js
```JSX
import Pane2 from './Pane2';
class Pane1 extends React.Component {
	// ...
	onButtonClick() {
		this.props.navigateTo(Pane2, { success: false });
	}
	// ...
}
```
Pane2.js
```JSX
class Pane2 extends React.Component {
	// ...
	render() {
		return <p>We {this.props.success ? 'did' : 'didn't'} succeed.</p>
	}
	// ...
}
```