### PR TITLE
Scrolls panes into view after navigation

### DIFF
--- a/order-form-ui/index.js
+++ b/order-form-ui/index.js
@@ -17,6 +17,5 @@ registerBlockType(
 
 const root = document.getElementById('pizzakit-order-form');
 if (root != null) {
-	const app = ReactDOM.render(<App />, root);
-	app.navigateTo(OrderForm, { post_address: '/' });
+	ReactDOM.render(<App defaultChild={OrderForm} defaultChildProps={{ post_address: '/' }} />, root);
 }

--- a/order-form-ui/src/App.js
+++ b/order-form-ui/src/App.js
@@ -5,7 +5,13 @@ class App extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.state = { ...App.defaultState };
+		this.state = {
+			childComponent: props.defaultChild || App.defaultState.childComponent,
+			childProps: props.defaultChildProps || App.defaultState.childProps
+		};
+
+		/** @type {React.RefObject<HTMLElement>} */
+		this.ref = React.createRef();
 	}
 
 	/**
@@ -25,7 +31,15 @@ class App extends React.Component {
 	}
 
 	render() {
-		return React.createElement(this.state.childComponent, { ...this.state.childProps, navigateTo: this.navigateTo.bind(this) });
+		return (
+			<div ref={this.ref}>
+				{React.createElement(this.state.childComponent, { ...this.state.childProps, navigateTo: this.navigateTo.bind(this) })}
+			</div>
+		);
+	}
+
+	componentDidUpdate() {
+		this.ref.current.scrollIntoView();
 	}
 }
 

--- a/order-form-ui/src/style.scss
+++ b/order-form-ui/src/style.scss
@@ -1,4 +1,4 @@
-#pizzakit-order-form > p {
+#pizzakit-order-form > div > p {
 	display: block;
 
 	label {
@@ -79,7 +79,7 @@
 	}
 }
 
-#pizzakit-order-form > .payment-confirmation {
+#pizzakit-order-form > div > .payment-confirmation {
 	display: flex;
 	flex-direction: column;
 	align-items: stretch;
@@ -176,7 +176,7 @@
 	}
 }
 
-#pizzakit-order-form > .confirm-page {
+#pizzakit-order-form > div > .confirm-page {
 	display: flex;
 	flex-direction: column;
 	align-items: center;


### PR DESCRIPTION
Fixes #20

When the state of app changes (only state changes is navigation) the apps root element will be scrolled into view.  
The newly added root element (a `div`) caused styles to break so they now have to start with `#pizzakit-order-form > div > ...`. I fixed that for existing styles.