### PR TITLE
Remove order form max width

### DIFF
--- a/order-form-ui/src/style.scss
+++ b/order-form-ui/src/style.scss
@@ -54,7 +54,6 @@
 		flex-wrap: wrap;
 		margin-left: 25px;
 		margin-bottom: 5px;
-		max-width: 420px;
 
 		label {
 			font-size: 2rem;

--- a/pizzakit-plugin/includes/items_for_sale.json
+++ b/pizzakit-plugin/includes/items_for_sale.json
@@ -5,7 +5,7 @@
 		{"name" : "Salami Mild", "price" : 20, "comment" : "5 skivor","main_item" : false},
 		{"name" : "Salami Stark", "price" : 20, "comment" : "5 skivor","main_item" : false},
 		{"name" : "Parmaskinka", "price" : 20, "comment" : "5 skivor","main_item" : false},
-		{"name" : "Prosciutto Cotto (kokt skinka)", "price" : 20, "comment" : "5 skivor","main_item" : false},
+		{"name" : "Prosciutto Cotto", "price" : 20, "comment" : "5 skivor","main_item" : false},
 		{"name" : "Buffelmozzarella", "price" : 25, "comment" : "125 g","main_item" : false},
 		{"name" : "En extra deg", "price" : 35, "comment" : null, "main_item" : false}
 	]


### PR DESCRIPTION
Closes #50.

Removes the max with from the order form, and removes the "(kokt skinka)" part from "Prosciutto Cotto" so that we can pretend our UI scales well.