### PR TITLE
No loading

### DIFF
--- a/order-form-ui/src/OrderForm.js
+++ b/order-form-ui/src/OrderForm.js
@@ -18,11 +18,11 @@ class OrderForm extends React.Component {
 
 		// Required for intercepting onChange events from <input>
 		this.handle_detail_update = this.handle_detail_update.bind(this);
-		// Create empty states, will be initialized by get_items()
-		this.items = [];
-		this.prices = new Map();
+
+		this.items = window.pizzakitItems;
+		this.prices = new Map(this.items.map(x => [x['name'],x['price']]));
 		this.state = {
-			cart : new Map(),
+			cart : new Map( this.items.map(x => [x['name'],0])),
 			email : '',
 			name : '',
 			telNr : '',
@@ -32,7 +32,6 @@ class OrderForm extends React.Component {
 			comments : '',
 			isLoading: false
 		};
-		this.get_items();
 	}
 
 	handle_cart_update(item,delta){
@@ -63,23 +62,6 @@ class OrderForm extends React.Component {
 			}
 		}
 		return false;
-	}
-
-	async get_items(){
-		const response = await fetch('/index.php/wp-json/pizzakit/items');
-		this.items = await response.json();
-		this.prices = new Map(this.items.map(x => [x['name'],x['price']]));
-		console.log(this.prices);
-		this.setState({
-			cart : new Map( this.items.map(x => [x['name'],0])),
-			email : '',
-			name : '',
-			telNr : '',
-			address : '',
-			doorCode : '',
-			postalCode : '',
-			comments : '',
-		});
 	}
 
 	async handle_submit(target_addr) {

--- a/pizzakit-plugin/includes/pizzakit-blocks.php
+++ b/pizzakit-plugin/includes/pizzakit-blocks.php
@@ -31,7 +31,16 @@ class Pizzakit_Blocks {
 		$items = $wpdb->get_results($sql);
 		$json = json_encode($items);
 
-		return '<script>window.pizzakitItems = ' . $json . ';</script><div id="pizzakit-order-form"></div>';
+		ob_start();
+		?>
+			<script>window.pizzakitItems = <?php echo($json); ?>;</script>
+			<div id="pizzakit-order-form">
+				<p class="has-text-align-center">
+					<strong>Pizzakit Order Formulär: Laddar...</strong>
+				</p>
+			</div>
+		<?php
+		return ob_get_clean();
 	}
 }
 

--- a/pizzakit-plugin/includes/pizzakit-blocks.php
+++ b/pizzakit-plugin/includes/pizzakit-blocks.php
@@ -26,7 +26,12 @@ class Pizzakit_Blocks {
 		);
 	}
 	public static function render_order_form($attributes, $content) {
-		return '<div id="pizzakit-order-form"></div>';
+		global $wpdb;
+		$sql = "SELECT * FROM wp_items";
+		$items = $wpdb->get_results($sql);
+		$json = json_encode($items);
+
+		return '<script>window.pizzakitItems = ' . $json . ';</script><div id="pizzakit-order-form"></div>';
 	}
 }
 


### PR DESCRIPTION
Instead of letting the client:

1. Load the JavaScript
2. Attach the React component
3. Request the menu items from the back-end
4. Wait for the menu items
5. And finally render the menu items

With this PR the client will receive the menu items together with the initial request of the document. That way, when the JavaScript loads the menu items are already loaded on the client and we can immediately render a fully loaded React component (with menu items and all).

0. Load document (also getting the menu items)
1. Load the JavaScript
2. Attach the React component

This PR can be merged instead of #60.