### PR TITLE
Policy

### DIFF
--- a/order-form-ui/src/OrderForm.js
+++ b/order-form-ui/src/OrderForm.js
@@ -63,7 +63,6 @@ class OrderForm extends React.Component {
 	}
 
 	async handle_submit(target_addr) {
-		console.log(target_addr);
 		if(this.is_fields_empty()){
 			alert('Vänligen fyll i alla obligatoriska fält');
 			return;

--- a/order-form-ui/src/OrderForm.js
+++ b/order-form-ui/src/OrderForm.js
@@ -3,6 +3,7 @@ import Small_item from './Items';
 import PaymentConfirmation from './PaymentConfirmation';
 import ConSuccess from './ConSuccess';
 import ConFailed from './ConFailed';
+import Policy from './Policy';
 
 // Main Application
 // Renders a form and keeps track of items the client has selected
@@ -62,8 +63,13 @@ class OrderForm extends React.Component {
 	}
 
 	async handle_submit(target_addr) {
+		console.log(target_addr);
 		if(this.is_fields_empty()){
-			alert('Var snäll och fyll i alla obligatoriska fält');
+			alert('Vänligen fyll i alla obligatoriska fält');
+			return;
+		}
+		if(!document.getElementById("policy").checked) {
+			alert('Vänligen godkänn köpvillkoren')
 			return;
 		}
 		const validation_results = this.check_validation();
@@ -135,6 +141,10 @@ class OrderForm extends React.Component {
 		json_obj.cart = cart;
 		json_obj.pizzakitFormSubmission = true;
 		return JSON.stringify(json_obj);
+	}
+
+	show_policy() {
+		this.props.navigateTo(Policy);
 	}
 
 	render() {
@@ -213,6 +223,10 @@ class OrderForm extends React.Component {
 							<option value="Kungsholmen">Kungsholmen</option>
 							<option value="Östermalm">Östermalm</option>
 						</select>
+					</div>
+					<div className="form-group">
+						<input type="checkbox" id="policy" name="policy" value="TRUE"></input>
+						<label htmlFor="policy">Jag godkänner <a onClick={() => this.show_policy()}>köpvillkoren</a><span>*</span>:</label>
 					</div>
 				</div>
 				<hr/>

--- a/order-form-ui/src/Policy.js
+++ b/order-form-ui/src/Policy.js
@@ -1,0 +1,56 @@
+import React from 'react';
+
+class Policy extends React.Component {
+	
+	render() {
+		return(
+			<div className="policy-page">
+				<h2>Köpvillkor</h2>
+				    <p>PRISER OCH BETALNING</p><p>
+
+                    Varje vara anges med pris inklusive moms. I kundvagnen kan man se det totala priset
+                    inklusive alla avgifter, moms, frakt och betalning.</p><p>
+
+                    ÅNGERRÄTT</p><p>
+
+                    Om du enligt Konsumentköplagen (SFS 1990:932) mottagit en felaktig vara har du rätt
+                    att reklamera den inom tre år på grund av felet. Reklamationen ska ske snarast
+                    efter att felet upptäckts. Om varan är felaktig kommer du att krediteras
+                    motsvarande belopp alternativt ersättas med en likvärdig vara om det inte innebär
+                    en oskälig kostnad för restaurangen.</p><p>
+
+                    Om du utnyttjar din ångerrätt är skyldig att hålla varan i lika gott skick som när
+                    du fick den. Du får inte använda den, men naturligtvis försiktigt undersöka den. Om
+                    varan skadas eller kommer bort på grund av att du är vårdslös förlorar du
+                    ångerrätten.</p><p>
+
+                    INTEGRITETSPOLICY</p><p>
+
+                    När du lägger din beställning hos oss uppger du dina personuppgifter. I samband med
+                    din registrering och beställning godkänner du att vi lagrar och använder dina
+                    uppgifter i vår verksamhet för att fullfölja avtalet gentemot dig enligt vår
+                    integritetspolicy som hittas i sin helhet [HÄR]. Du har enligt Personuppgiftslagen
+                    rätt att få den information som vi har registrerat om dig. Om den är felaktig,
+                    ofullständig eller irrelevant kan du begära att informationen ska rättas eller tas
+                    bort. Kontakta oss i så fall via e-post.</p><p>
+
+                    RETURER</p><p>
+
+                    Returer sker på din egen bekostnad utom om varan är defekt eller om vi har packat
+                    fel.</p><p>
+
+                    EJ UTHÄMTADE VAROR</p><p>
+
+                    Om du inte hämtat ut dina varor inom avtalat tidsintervall är du skyldig att
+                    kontakta restaurangen. Restaurangen har rätt att debitera dig för hela ordern, men
+                    ej uthämtade varor kan förvaras under skälig tid efter överenskommelse, i mån av
+                    utrymme och tid.</p><p>
+
+                    Se även konsumentverket och distansavtalslagen, samt EU:s gemensamma
+                    tvistlösningssida http://ec.europa.eu/odr.</p>
+			</div>
+		);
+	}
+}
+
+export default Policy;


### PR DESCRIPTION
Added a page for köpvillkor and a checkbox that needs to be checked before the order can be placed. There is a link to the new page next to the checkbox, however this DOES NOT open in a new tab. It can open in a new tab if we create a new wordpress page, but not sure what we think is best.